### PR TITLE
Implemented toy limits, single toy on page, shop tests

### DIFF
--- a/app/src/main/java/com/example/workoutholicapp/ui/buddy/BuddyFragment.java
+++ b/app/src/main/java/com/example/workoutholicapp/ui/buddy/BuddyFragment.java
@@ -2,6 +2,7 @@ package com.example.workoutholicapp.ui.buddy;
 
 import android.media.Image;
 import android.os.Bundle;
+import android.os.CountDownTimer;
 import android.os.Handler;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -37,7 +38,7 @@ public class BuddyFragment extends Fragment {
     private Handler handler;
     private final int intervalInMillis = 24 * 60 * 60 * 1000; // 1 day in milliseconds
     //private final int intervalInMillis = 5000; // for testing/demo purposes
-
+    private boolean[] isTime;
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -47,6 +48,7 @@ public class BuddyFragment extends Fragment {
         hungerLevel = 0;
         thirstLevel = 0;
         happinessLevel = 0;
+        isTime = new boolean[]{true, true, true};
     }
 
     private void scheduleHungerLevelUpdate() {
@@ -307,37 +309,114 @@ public class BuddyFragment extends Fragment {
 
         // dog "plays with" ball if ball is currently selected
         ImageButton ball = root.findViewById(R.id.dog_toy1);
+        TextView warning = root.findViewById(R.id.dialog_title);
+        final long[] timeLeftInMillis = {0, 0, 0};
         ball.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 ImageView toy = getView().findViewById(R.id.toy_ball);
+                ImageView bone = getView().findViewById(R.id.toy_bone);
+                ImageView stick = getView().findViewById(R.id.toy_stick);
+                bone.setAlpha(0.0f);
+                stick.setAlpha(0.0f);
                 boolean isEnabled = mainViewModel.toys().getValue()[0];
                 if(isEnabled){
-                    if (toy.getAlpha() == 0.0f) {
+                    if (toy.getAlpha() == 0.0f && isTime[0]) {
                         toy.setAlpha(1.0f);
                         changeHappiness();
+                        warning.setAlpha(0.0f);
+                        isTime[0] = false;
+                        CountDownTimer timer = new CountDownTimer(2 * 60 * 60 * 1000, 1000) {
+                            @Override
+                            public void onTick(long millisUntilFinished) {
+                                timeLeftInMillis[0] = millisUntilFinished;
+                            }
+
+                            @Override
+                            public void onFinish() {
+                                // Timer finished, handle as needed
+                                isTime[0] = true;
+                            }
+                        };
+                        timer.start();
+                    } else if (toy.getAlpha() == 0.0f) {
+                        int seconds = (int) ((timeLeftInMillis[0] / 1000));
+                        String message = "";
+                        if (seconds > 3600) {
+                            message = "Wait " +  seconds / 3600 + "h " +  (seconds % 3600) / 60 + "m to play with this toy again!";
+                        } else if (seconds > 60) {
+                            message = "Wait " +  seconds / 60 + "m " + seconds % 60 +  "s to play with this toy again!";
+                        } else {
+                            message = "Wait " +  seconds + "s to play with this toy again!";
+                        }
+                        warning.setText(message);
+                        warning.setAlpha(1.0f);
+                        Handler handler = new Handler();
+                        handler.postDelayed(new Runnable() {
+                            @Override
+                            public void run() {
+                                warning.setAlpha(0.0f);
+                            }
+                        }, 5 * 1000); // 5 seconds in milliseconds
+                    } else {
+                        toy.setAlpha(0.0f);
                     }
-                } else  {
-                    toy.setAlpha(0.0f);
                 }
             }
         });
+
 
         ImageButton bone = root.findViewById(R.id.dog_toy2);
         bone.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 ImageView toy = getView().findViewById(R.id.toy_bone);
+                ImageView ball = getView().findViewById(R.id.toy_ball);
+                ImageView stick = getView().findViewById(R.id.toy_stick);
+                ball.setAlpha(0.0f);
+                stick.setAlpha(0.0f);
                 boolean isEnabled = mainViewModel.toys().getValue()[1];
                 if(isEnabled){
-                    if (toy.getAlpha() == 0.0f) {
+                    if (toy.getAlpha() == 0.0f && isTime[1]) {
                         toy.setAlpha(1.0f);
                         changeHappiness();
+                        warning.setAlpha(0.0f);
+                        isTime[1] = false;
+                        CountDownTimer timer = new CountDownTimer(2 * 60 * 60 * 1000, 1000) {
+                            @Override
+                            public void onTick(long millisUntilFinished) {
+                                timeLeftInMillis[1] = millisUntilFinished;
+                            }
+
+                            @Override
+                            public void onFinish() {
+                                // Timer finished, handle as needed
+                                isTime[1] = true;
+                            }
+                        };
+                        timer.start();
+                    } else if (toy.getAlpha() == 0.0f) {
+                        int seconds = (int) ((timeLeftInMillis[1] / 1000));
+                        String message = "";
+                        if (seconds > 3600) {
+                            message = "Wait " +  seconds / 3600 + "h " +  (seconds % 3600) / 60 + "m to play with this toy again!";
+                        } else if (seconds > 60) {
+                            message = "Wait " +  seconds / 60 + "m " + seconds % 60 +  "s to play with this toy again!";
+                        } else {
+                            message = "Wait " + seconds + "s to play with this toy again!";
+                        }
+                        warning.setText(message);
+                        warning.setAlpha(1.0f);
+                        Handler handler = new Handler();
+                        handler.postDelayed(new Runnable() {
+                            @Override
+                            public void run() {
+                                warning.setAlpha(0.0f);
+                            }
+                        }, 5 * 1000); // 5 seconds in milliseconds
                     } else {
                         toy.setAlpha(0.0f);
                     }
-                } else {
-                    toy.setAlpha(0.0f);
                 }
             }
         });
@@ -347,16 +426,52 @@ public class BuddyFragment extends Fragment {
             @Override
             public void onClick(View view) {
                 ImageView toy = getView().findViewById(R.id.toy_stick);
+                ImageView ball = getView().findViewById(R.id.toy_ball);
+                ImageView bone = getView().findViewById(R.id.toy_bone);
+                ball.setAlpha(0.0f);
+                bone.setAlpha(0.0f);
                 boolean isEnabled = mainViewModel.toys().getValue()[2];
-                if(isEnabled){
-                    if (toy.getAlpha() == 0.0f) {
+                if (isEnabled) {
+                    if (toy.getAlpha() == 0.0f && isTime[2]) {
                         toy.setAlpha(1.0f);
                         changeHappiness();
+                        warning.setAlpha(0.0f);
+                        isTime[2] = false;
+                        CountDownTimer timer = new CountDownTimer(2 * 60 * 60 * 1000, 1000) {
+                            @Override
+                            public void onTick(long millisUntilFinished) {
+                                timeLeftInMillis[2] = millisUntilFinished;
+                            }
+
+                            @Override
+                            public void onFinish() {
+                                // Timer finished, handle as needed
+                                isTime[2] = true;
+                            }
+                        };
+                        timer.start();
+                    } else if (toy.getAlpha() == 0.0f) {
+                        int seconds = (int) ((timeLeftInMillis[2] / 1000));
+                        String message = "";
+                        if (seconds > 3600) {
+                            message = "Wait " +  seconds / 3600 + "h " +  (seconds % 3600) / 60 + "m to play with this toy again!";
+                        } else if (seconds > 60) {
+                            message = "Wait " +  seconds / 60 + "m " + seconds % 60 +  "s to play with this toy again!";
+                        } else {
+                            message = "Wait " + seconds + "s to play with this toy again!";
+                        }
+                        warning.setText(message);
+                        warning.setAlpha(1.0f);
+                        Handler handler = new Handler();
+                        handler.postDelayed(new Runnable() {
+                            @Override
+                            public void run() {
+                                warning.setAlpha(0.0f);
+                            }
+                        }, 5 * 1000); // 5 seconds in milliseconds
                     } else {
                         toy.setAlpha(0.0f);
                     }
-                } else {
-                    toy.setAlpha(0.0f);
                 }
             }
         });

--- a/app/src/main/res/layout/fragment_buddy.xml
+++ b/app/src/main/res/layout/fragment_buddy.xml
@@ -478,4 +478,23 @@
 
     />
 
+    <TextView
+        android:id="@+id/dialog_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:alpha="0.0"
+        android:gravity="center"
+        android:layout_marginBottom="180dp"
+        android:text="Wait 2 hours to play with this toy again!"
+        android:textSize="18sp"
+
+        android:textStyle="bold"
+
+
+        tools:layout_editor_absoluteX="-16dp"
+        tools:layout_editor_absoluteY="531dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/example/workoutholicapp/BasicShopTests.java
+++ b/app/src/test/java/com/example/workoutholicapp/BasicShopTests.java
@@ -66,4 +66,19 @@ public class BasicShopTests {
         assertEquals(15, food);
     }
 
+    public void testAutoEnoughMoney() {
+        MainViewModel vm = new MainViewModel();
+        vm.setMoney(150);
+        vm.buyAuto(1);
+        int money = vm.moneyAmount().getValue();
+        assertEquals(50, money);
+    }
+
+    public void testToyEnoughMoney() {
+        MainViewModel vm = new MainViewModel();
+        vm.setMoney(150);
+        vm.buyToyClick(1);
+        int money = vm.moneyAmount().getValue();
+        assertEquals(130, money);
+    }
 }


### PR DESCRIPTION
Implemented toy limits:
Now when a user plays with a toy, there is a 2 hour limit until they can use that toy again, so they cannot fill their happiness level all at once. There is also a message that shows up when the user tries to click on the same toy within the limit saying how much they have left until they can use that toy again. 
Single toy on page:
Only one toy shows up on a screen. If a user has a toy being used and they click on another toy, the current toy will disappear.
Shop tests:
Tests that test the case where the user buys an auto-fill feature and a toy. 